### PR TITLE
Refactor Barsize mapping for #15

### DIFF
--- a/add-visits.js
+++ b/add-visits.js
@@ -28,15 +28,29 @@ alterState(state => {
   };
 
   function getBarSize(matched_value) {
-    return miracleFeetBarSizeMap[matched_value]
-      ? miracleFeetBarSizeMap[matched_value]
-      : '-';
+    let bar_size = '-';
+
+    for (const [key, value] of Object.entries(miracleFeetBarSizeMap)) {
+      if (parseFloat(key) === parseFloat(matched_value)) {
+        bar_size = value;
+        break;
+      }
+    }
+    if (matched_value !== 'Invalid' && bar_size === '-') {
+      throw new TypeError(
+        `The current miracleFeetBarSizeMap is outdated! The data shows we have received a new bar size(${matched_value}) from the client! Please update miracleFeetBarSizeMap with a new entry for this value: ${matched_value}`,
+        'add-visits.js',
+        24
+      );
+    }
+
+    return bar_size;
   }
 
   function searchBarSizeStringByRegex(str) {
-    let regExp = /(\d+\s*mm$)/g;
-    let matches = str.trim().match(regExp);
-    return matches ? matches[0] : 'Invalid';
+    let regExp = /((\d+(\.\d+)?)\s*mm)/g;
+    let matches = regExp.exec(str.trim());
+    return matches ? matches[1] : 'Invalid';
   }
 
   state.data = {


### PR DESCRIPTION
@aleksa-krolls, I have refactored the methods for **Bar Size mapping** with improved scenarios:

### 1. Client sends new un-mapped valid bar size in the payload

- With this pull request, we **fail the job** with a **TypeError**, and request **OpenFn support** to **add the new mapping**(after confirming with the client) to `miracleFeetBarSizeMap`.

- With this pull request, the following **example payloads** would raise the **TypeError** since they match the **valid bar size** pattern but **not yet mapped**: We do not want to exclude them from the **Upsert payload**, chances are, this is a newly added mapping so we catch it:

- `300 mm`,`300mm`,`300.0mm`,`300.0 mm`

### 2. Client sends payload with valid bar size in a different position of the field text

- With this pull request, we are able to extract the **valid bar size** from **anywhere in the text,** and map it correctly. The following scenarios would **pass the tests**:

| Payload | Resulting Mapped Bar Size |
| ------------- | ------------- |
| miraclefeet Bar Size 1 - 180 mm  | Extra Small |
| miraclefeet Bar Size 1 - 180.0 mm  | Extra Small |
| 180 mm miraclefeet Bar Size 1  | Extra Small |
| 180.0 mm miraclefeet Bar Size 1  | Extra Small |
| miraclefeet Bar 180 mm Size 1  | Extra Small |
| 180 mm | Extra Small |
| random text 180 mm some new text  | Extra Small |

### 3. Client sends payload with bar size without units or with different units other than `mm`
- We allow the job to run but we **exclude** the field from the **Upsert payload** via the **Clean()** method.
- Should we maintain this behaviour? What should we do when they send a value like this ` miraclefeet Bar Size 1 - 180` or `180`, without units?
